### PR TITLE
update about: now software engineer @ copilotkit

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -83,7 +83,11 @@
     <ul>
       <li>i like programming and making things</li>
       <li>
-        currently, recurser @
+        currently, software engineer @
+        <a href="https://www.copilotkit.ai/">copilotkit</a>
+      </li>
+      <li>
+        previously, recurser @
         <a href="https://www.recurse.com/">recurse center</a>
       </li>
       <li>


### PR DESCRIPTION
Updates the **about** section on the homepage to reflect the new role.

## what changed
- **current role** is now `software engineer @ copilotkit` → links to https://www.copilotkit.ai/
- **recurse center** moves to a `previously` entry (kept above vercel, most-recent-first)
- vercel entry unchanged

## design notes
Followed the existing site conventions exactly — all-lowercase, same `<li>` markup, same 6-space indentation and anchor format. Nothing else touched (age span, location, projects, build scripts, and styles all untouched).

## verification
- ✅ `bun run scripts/build.ts` builds cleanly (main site + 12 posts + vercel page)
- ✅ built `dist/index.html` contains the new copy
